### PR TITLE
Move 'use strict'; inside of containing function

### DIFF
--- a/jquery.rm.js
+++ b/jquery.rm.js
@@ -16,8 +16,8 @@
  * to render your ideal measure.
  *
  */
-'use strict';
 (function($) {
+  'use strict';
 
   function calculateIdealLineLength() {
     //  Set to Bringhurst's recommendation for an ideal measure


### PR DESCRIPTION
It is dangerious to put 'use strict' outside of a containing
function—if you concatenate this file with others when deploying a
site (as you should), then it'll throw the entire set of scripts
into strict mode, which could cause disastrous incompatibilities for
projects developed without 'use strict' in mind.
