### PR TITLE
Throw Errors instead of logging to console

### DIFF
--- a/jquery.rm.js
+++ b/jquery.rm.js
@@ -101,14 +101,14 @@
       return;
     } else if(this.length != 1) {
       //  Too many elements
-      console.log("responsiveMeasure must be applied with a selector that matches only one element.");
+      throw new Error("responsiveMeasure must be applied with a selector that matches only one element.");
       return;
     }
 
     var $element = this;
     var idealLineLength = typeof(opts.idealLineLength) == 'function' ? opts.idealLineLength.call(this, $element) : parseInt(opts.idealLineLength, 10);
     if (idealLineLength == 0) {
-      console.warn("responsiveMeasure was given an ideal line length of 0; this doesn't make any sense. Doing nothing.");
+      throw new Error("responsiveMeasure was given an ideal line length of 0; this doesn't make any sense. Doing nothing.");
       return;
     }
 


### PR DESCRIPTION
Not all browsers have `console` defined. Also, both of these cases
where you logged to the console were cases where the user was
potentially using the library incorrectly. Throwing errors will
alert the user immediately that they are doing something wrong, and
will provide them with the means to fix the problem.
