### PR TITLE
Add target option

### DIFF
--- a/jquery.rm.js
+++ b/jquery.rm.js
@@ -123,7 +123,14 @@
     var fontRatios = fontRatiosForFontSize(idealFontSize, opts.ratio, opts.scaleIncrements, opts.minimumFontSize);
 
     var $docElement = $(document.documentElement);
-    $docElement.css('font-size', idealFontSize + 'px');
+
+    if (opts.target) {
+      var $targetElement = $(opts.target);
+    } else {
+      var $targetElement = $docElement;
+    }
+
+    $targetElement.css('font-size', idealFontSize + 'px');
     $docElement.trigger('responsiveMeasureUpdated', {
       idealFontSize: idealFontSize,
       fontRatios: fontRatios


### PR DESCRIPTION
This allows one to specify a target jquery selector for the font-size rule to be applied to. Default behavior is still applying it to the documentElement. Obviously this is kind of a dumb implementation, because it doesn't apply to any elements that are dynamically created or changed.
